### PR TITLE
Only inject link tags in head if document is available

### DIFF
--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -1,12 +1,14 @@
-const preconnectLink = document.createElement('link');
-preconnectLink.rel = 'preconnect';
-preconnectLink.href = 'https://rsms.me/';
-document.head.appendChild(preconnectLink);
+if (document) {
+    const preconnectLink = document.createElement('link');
+    preconnectLink.rel = 'preconnect';
+    preconnectLink.href = 'https://rsms.me/';
+    document.head.appendChild(preconnectLink);
 
-const stylesheetLink = document.createElement('link');
-stylesheetLink.rel = 'stylesheet';
-stylesheetLink.href = 'https://rsms.me/inter/inter.css';
-document.head.appendChild(stylesheetLink);
+    const stylesheetLink = document.createElement('link');
+    stylesheetLink.rel = 'stylesheet';
+    stylesheetLink.href = 'https://rsms.me/inter/inter.css';
+    document.head.appendChild(stylesheetLink);
+}
 
 export * from './components/Connection/Connection.types';
 export * from './components/Canvas/Canvas.types';


### PR DESCRIPTION
In support of issue #7, this should cover the explicit reference to `document`.